### PR TITLE
Update URL encoding of build_link search parameter

### DIFF
--- a/ClassML.py
+++ b/ClassML.py
@@ -1,6 +1,6 @@
 import requests as rq
 import json
-
+import urllib.parse
 
 
     
@@ -15,7 +15,7 @@ class SearchML():
     #builds API link in accordance to the parameters provided in a list
     #[search, lowest_price, floor_price, forbidden_words, required words, forbidden_ids, condition]
     def build_link(self, search_parameters):
-        search=search_parameters[0].replace(" ", "%20")
+        search=urllib.parse.quote(search_parameters[0])
         return self.url.format(search, search_parameters[6])
     
     


### PR DESCRIPTION
Instead of just replacing spaces with "%20" in the build_link function, I imported a URL library to fully encode any utf-8 source
text into a valid URL string. Awesome idea by the way. Saw it on the python subreddit and thought it was super cool. 